### PR TITLE
Fixed Spy Survived Event missing Icon and always triggering

### DIFF
--- a/lua/terrortown/events/spy_alive.lua
+++ b/lua/terrortown/events/spy_alive.lua
@@ -1,7 +1,6 @@
 EVENT.base = "base_event"
 
 if SERVER then
-	AddCSLuaFile()
 	resource.AddFile("materials/vgui/ttt/vskin/events/spy_alive.vmt")
 end
 

--- a/lua/terrortown/events/spy_alive.lua
+++ b/lua/terrortown/events/spy_alive.lua
@@ -21,6 +21,7 @@ if SERVER then
 	function EVENT:Trigger()
 		local plys = player.GetAll()
 		local eventPlys = {}
+		local spyAlive = false
 
 		for i = 1, #plys do
 			local ply = plys[i]
@@ -36,7 +37,12 @@ if SERVER then
 				nick = ply:Nick(),
 				sid64 = ply:SteamID64()
 			}
+
+			-- only add this event if a spy is alive
+			spyAlive = true
 		end
+
+		if not spyAlive then return end
 
 		return self:Add({plys = eventPlys})
 	end
@@ -61,19 +67,6 @@ end
 -- trigger this event once the round ended but before the events are synced
 hook.Add("TTT2AddedEvent", "trigger_spy_survival_event", function(type)
 	if type ~= EVENT_FINISH then return end
-
-	local plys = util.GetAlivePlayers()
-	local spyAlive = false
-
-	for i = 1, #plys do
-		if plys[1]:GetSubRole() ~= ROLE_SPY then continue end
-
-		spyAlive = true
-
-		break
-	end
-
-	if not spyAlive then return end
 
 	events.Trigger(EVENT_SPY_ALIVE)
 end)

--- a/lua/terrortown/events/spy_alive.lua
+++ b/lua/terrortown/events/spy_alive.lua
@@ -63,11 +63,17 @@ hook.Add("TTT2AddedEvent", "trigger_spy_survival_event", function(type)
 	if type ~= EVENT_FINISH then return end
 
 	local plys = util.GetAlivePlayers()
+	local spyAlive = false
+
 	for i = 1, #plys do
-		if plys[1]:GetSubRole() == ROLE_SPY then
-			events.Trigger(EVENT_SPY_ALIVE)
-			return
-		end
+		if plys[1]:GetSubRole() ~= ROLE_SPY then continue end
+
+		spyAlive = true
+
+		break
 	end
 
+	if not spyAlive then return end
+
+	events.Trigger(EVENT_SPY_ALIVE)
 end)

--- a/lua/terrortown/events/spy_alive.lua
+++ b/lua/terrortown/events/spy_alive.lua
@@ -64,7 +64,6 @@ hook.Add("TTT2AddedEvent", "trigger_spy_survival_event", function(type)
 	if type ~= EVENT_FINISH then return end
 
 	local plys = util.GetAlivePlayers()
-	local wasSpy = false
 	for i = 1, #plys do
 		if plys[1]:GetSubRole() == ROLE_SPY then
 			events.Trigger(EVENT_SPY_ALIVE)

--- a/lua/terrortown/events/spy_alive.lua
+++ b/lua/terrortown/events/spy_alive.lua
@@ -1,5 +1,10 @@
 EVENT.base = "base_event"
 
+if SERVER then
+	AddCSLuaFile()
+	resource.AddFile("materials/vgui/ttt/vskin/events/spy_alive.vmt")
+end
+
 if CLIENT then
 	EVENT.icon = Material("vgui/ttt/vskin/events/spy_alive")
 	EVENT.title = "title_event_spy_alive"
@@ -58,5 +63,13 @@ end
 hook.Add("TTT2AddedEvent", "trigger_spy_survival_event", function(type)
 	if type ~= EVENT_FINISH then return end
 
-	events.Trigger(EVENT_SPY_ALIVE)
+	local plys = util.GetAlivePlayers()
+	local wasSpy = false
+	for i = 1, #plys do
+		if plys[1]:GetSubRole() == ROLE_SPY then
+			events.Trigger(EVENT_SPY_ALIVE)
+			return
+		end
+	end
+
 end)


### PR DESCRIPTION
Added a resource.AddFile for the icon to ensure it's loaded on client.

Added a check before triggering the event to see if there are actually any Spies currently alive.