### PR TITLE
Fix spy role not checking unknownTeam

### DIFF
--- a/lua/terrortown/entities/roles/spy/shared.lua
+++ b/lua/terrortown/entities/roles/spy/shared.lua
@@ -180,7 +180,7 @@ if SERVER then
 				local traitors = {}
 
 				for _, ply in ipairs(player.GetAll()) do
-					if ply:IsActive() and ply:IsTraitor() then
+					if ply:IsActive() and ply:IsTraitor() and not ply:GetSubRoleData().unknownTeam then
 						traitors[#traitors + 1] = ply
 					end
 				end


### PR DESCRIPTION
The spy role was not checking whether the role of the other players has unknownTeam set to true when sending fake buy notifications. 
This causes roles that are traitor, but not supposed to know it yet to see the buy notification and gain the knowledge that they are traitor. This small change fixes that.